### PR TITLE
Añadido el skeleton layout a la parte de videoGames

### DIFF
--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesFragment.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesFragment.kt
@@ -9,11 +9,12 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.faltenreich.skeletonlayout.Skeleton
+import com.faltenreich.skeletonlayout.applySkeleton
 import com.google.android.material.appbar.MaterialToolbar
 import edu.iesam.gametracker.MainActivity
 import edu.iesam.gametracker.R
 import edu.iesam.gametracker.databinding.FragmentVideogamesBinding
-import edu.iesam.gametracker.features.videogames.domain.Videogame
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class VideogamesFragment : Fragment() {
@@ -26,6 +27,8 @@ class VideogamesFragment : Fragment() {
     private var isShowingFavorites = false
     private val videogamesAdapter: VideogamesAdapter = VideogamesAdapter()
 
+    private lateinit var skeleton: Skeleton
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -36,14 +39,17 @@ class VideogamesFragment : Fragment() {
     }
 
     private fun setupView() {
-        binding.videogameList.layoutManager = LinearLayoutManager(requireContext())
+        binding.apply {
+            videogameList.layoutManager = LinearLayoutManager(requireContext())
+            videogameList.adapter = videogamesAdapter
+            skeleton = videogameList.applySkeleton(R.layout.view_videogames_item, 8)
+        }
         videogamesAdapter.setOnItemClickListener { videGame ->
             viewModel.toggleFavorite(videGame, isShowingFavorites)
         }
         videogamesAdapter.setOnDetailClickListener { videogame ->
             navigateToVideogameDetail(videogame.id)
         }
-        binding.videogameList.adapter = videogamesAdapter
         (requireActivity() as MainActivity).findViewById<MaterialToolbar>(R.id.toolbar)
     }
 
@@ -83,6 +89,11 @@ class VideogamesFragment : Fragment() {
 
     private fun setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner, Observer { uiState ->
+            if (uiState.isLoading) {
+                skeleton.showSkeleton()
+            } else {
+                skeleton.showOriginal()
+            }
             uiState.videogames?.let { videogames ->
                 videogamesAdapter.submitList(videogames)
             }

--- a/app/src/main/res/layout/view_videogames_item.xml
+++ b/app/src/main/res/layout/view_videogames_item.xml
@@ -7,6 +7,11 @@
     android:padding="8dp"
     android:orientation="vertical">
 
+    <com.faltenreich.skeletonlayout.SkeletonLayout
+        android:id="@+id/skeleton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -80,5 +85,7 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.cardview.widget.CardView>
+
+    </com.faltenreich.skeletonlayout.SkeletonLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
Se requiere mejorar la experiencia de usuario en la pantalla de listado de videojuegos añadiendo una animación de carga (Skeleton Layout) y, además, implementar Safe Args en la navegación para garantizar el paso de argumentos de forma segura y tipada, eliminando el uso manual de Bundles.

## 💡 Proceso seguido para resolver el problema.
-  Se investigó la librería [SkeletonLayout](https://github.com/Faltenreich/SkeletonLayout) para utilizarla en la pantalla de lista de videojuegos.

- Se configuró el método applySkeleton en la vista del RecyclerView para mostrar 8 items placeholder durante la carga.

## 📝 Pruebas de validación
- Se realizaron pruebas unitarias y de integración en entornos de desarrollo para verificar que el skeleton se mostrara mientras se cargaban los datos y luego se visualizara la lista real.

 - Se comprobó que, al pulsar sobre el elemento de la lista, se navega correctamente al detalle, recibiendo el videojuego correspondiente sin errores de tipo.

## 👩‍💻 Resumen de los cambios introducidos
- Se añadió la función applySkeleton al RecyclerView en VideogamesFragment usando el layout view_videogames_item.xml como placeholder para el skeleton.

- Se controla la visibilidad del skeleton dependiendo del flag isLoading en el LiveData del ViewModel.

## 📸 Screenshot o Video
<img width="430" alt="Captura de pantalla 2025-04-14 a las 22 46 28" src="https://github.com/user-attachments/assets/9deae03c-3e19-4f70-a1f5-50d5a463cbf1" />


## ✋ Notas adicionales (Disclaimer)
Se recomienda hacer pruebas en diferentes dispositivos para confirmar que la animación y la navegación funcionan correctamente en todos los escenarios, no se añadio el safeArgs porque ya estaba implementado al añadir el detalle de los videojuegos

## 🌈 Añade un Gif que represente a esta PR
![chefs-kiss-french-chef](https://github.com/user-attachments/assets/396adedb-5fda-4672-99f9-dabe26804827)


## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He relacionado la PR con la Issue.

