### PR TITLE
Ocultar API Key y Añadir Géneros al Listado de Videojuegos

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -5,9 +7,21 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
+val localProps = Properties().apply {
+    rootProject.file("local.properties")
+        .takeIf { it.exists() }
+        ?.inputStream()
+        ?.use { load(it) }
+}
+val apiKey: String = localProps.getProperty("API_KEY") ?: ""
+
 android {
     namespace = "edu.iesam.gametracker"
     compileSdk = 35
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
         applicationId = "edu.iesam.gametracker"
@@ -17,6 +31,8 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "API_KEY", "\"$apiKey\"")
     }
 
     buildTypes {
@@ -39,6 +55,7 @@ android {
     viewBinding {
         enable = true
     }
+
 }
 
 dependencies {

--- a/app/src/main/java/edu/iesam/gametracker/app/data/local/db/GameTrackerDataBase.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/data/local/db/GameTrackerDataBase.kt
@@ -3,6 +3,7 @@ package edu.iesam.gametracker.app.data.local.db
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import edu.iesam.gametracker.app.data.local.db.converters.Converters
 import edu.iesam.gametracker.features.videogames.data.local.db.FavoriteDao
 import edu.iesam.gametracker.features.videogames.data.local.db.FavoriteEntity
 import edu.iesam.gametracker.features.videogames.data.local.db.VideogamesDao
@@ -13,11 +14,11 @@ import edu.iesam.gametracker.features.videogames.data.local.db.VideogamesEntity
         VideogamesEntity::class,
         FavoriteEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = false
 )
 
-@TypeConverters()
+@TypeConverters(Converters::class)
 abstract class GameTrackerDataBase : RoomDatabase() {
     abstract fun videogamesDao(): VideogamesDao
     abstract fun favoriteDao(): FavoriteDao

--- a/app/src/main/java/edu/iesam/gametracker/app/data/local/db/converters/Converter.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/data/local/db/converters/Converter.kt
@@ -1,0 +1,22 @@
+package edu.iesam.gametracker.app.data.local.db.converters
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import edu.iesam.gametracker.features.videogames.domain.Genre
+
+object Converters {
+    private val gson = Gson()
+
+    @TypeConverter
+    @JvmStatic
+    fun fromGenres(genres: List<Genre>): String =
+        gson.toJson(genres)
+
+    @TypeConverter
+    @JvmStatic
+    fun toGenres(json: String): List<Genre> {
+        val type = object : TypeToken<List<Genre>>() {}.type
+        return gson.fromJson(json, type)
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/data/local/db/DbMappers.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/data/local/db/DbMappers.kt
@@ -10,7 +10,8 @@ fun Videogame.toEntity(): VideogamesEntity {
         this.backgroundImage,
         this.rating,
         this.playtime,
-        this.description
+        this.description,
+        this.genres
     )
 }
 
@@ -24,6 +25,7 @@ fun VideogamesEntity.toDomain(): Videogame{
         this.backgroundImage,
         this.rating,
         this.playtime,
-        this.description
+        this.description,
+        this.genres
     )
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/data/local/db/VideogamesEntity.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/data/local/db/VideogamesEntity.kt
@@ -3,6 +3,7 @@ package edu.iesam.gametracker.features.videogames.data.local.db
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import edu.iesam.gametracker.features.videogames.domain.Genre
 
 
 const val VIDEOGAME_TABLE = "videogame"
@@ -16,6 +17,7 @@ class VideogamesEntity(
     @ColumnInfo(name = "background_image") val backgroundImage: String,
     @ColumnInfo(name = "rating") val rating: Double,
     @ColumnInfo(name = "playtime") val playtime: Int,
-    @ColumnInfo(name = "description") val description: String
+    @ColumnInfo(name = "description") val description: String,
+    @ColumnInfo(name = "genres") val genres: List<Genre>
 )
 

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/data/remote/VideogamesApiMapper.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/data/remote/VideogamesApiMapper.kt
@@ -1,5 +1,6 @@
 package edu.iesam.gametracker.features.videogames.data.remote
 
+import edu.iesam.gametracker.features.videogames.domain.Genre
 import edu.iesam.gametracker.features.videogames.domain.Videogame
 
 fun VideogamesApiModel.toModel(): Videogame {
@@ -10,6 +11,12 @@ fun VideogamesApiModel.toModel(): Videogame {
         this.backgroundImage,
         this.rating,
         this.playtime,
-        this.description.toString()
+        this.description.toString(),
+        this.genres.map {
+            Genre(
+                it.id,
+                it.name
+            )
+        }
     )
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/data/remote/VideogamesApiModel.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/data/remote/VideogamesApiModel.kt
@@ -9,5 +9,11 @@ data class VideogamesApiModel (
     @SerializedName("background_image") val backgroundImage: String,
     @SerializedName("rating") val rating: Double,
     @SerializedName("playtime") val playtime: Int,
-    @SerializedName("description_raw") val description: String?
+    @SerializedName("description_raw") val description: String?,
+    @SerializedName("genres") val genres: List<GenreApiModel>
+)
+
+data class GenreApiModel(
+    @SerializedName("id") val id : Int,
+    @SerializedName("name") val name: String,
 )

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/data/remote/VideogamesService.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/data/remote/VideogamesService.kt
@@ -1,15 +1,17 @@
 package edu.iesam.gametracker.features.videogames.data.remote
 
+import edu.iesam.gametracker.BuildConfig
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+
 interface VideogamesService {
 
     @GET("games")
     suspend fun requestVideogames(
-        @Query("key") apiKey: String = "c2c4ac233f0e46eca79e7ab82b1bdbef",
+        @Query("key") apiKey: String = BuildConfig.API_KEY,
         @Query("page") page: Int = 1,
         @Query("page_size") pageSize: Int = 50
     ): Response<RawgResponse>
@@ -17,7 +19,7 @@ interface VideogamesService {
     @GET("games/{id}")
     suspend fun requestVideogameDetail(
         @Path("id") videogameId: Int,
-        @Query("key") apiKey: String = "c2c4ac233f0e46eca79e7ab82b1bdbef"
+        @Query("key") apiKey: String = BuildConfig.API_KEY
     ): Response<VideogamesApiModel>
 }
 

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/domain/Videogame.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/domain/Videogame.kt
@@ -7,6 +7,12 @@ data class Videogame (
     val backgroundImage: String,
     val rating: Double,
     val playtime: Int,
-    val description: String
+    val description: String,
+    val genres : List<Genre>
+)
+
+data class Genre(
+    val id: Int,
+    val name: String,
 )
 

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogameDetailFragment.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogameDetailFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
+import edu.iesam.gametracker.R
 import edu.iesam.gametracker.app.extensions.loadUrl
 import edu.iesam.gametracker.databinding.FragmentVideogameDetailBinding
 import edu.iesam.gametracker.features.videogames.domain.Videogame
@@ -51,8 +52,14 @@ class VideogameDetailFragment : Fragment() {
         binding.apply {
             imageDetail.loadUrl(videogame.backgroundImage)
             nameGame.text = videogame.name
-            playtime.text = videogame.playtime.toString()
-            released.text = videogame.released
+            playtime.text = root.context.getString(
+                R.string.playtime,
+                videogame.playtime.toString()
+            )
+            released.text = root.context.getString(
+                R.string.released_date,
+                videogame.released
+            )
             description.text = videogame.description.toString()
         }
     }

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
@@ -22,8 +22,16 @@ class VideogamesViewHolder(private val view: View) : RecyclerView.ViewHolder(vie
         binding.apply {
             image.loadUrl(videogameFeed.videogame.backgroundImage)
             nameGame.text = videogameFeed.videogame.name
-            released.text = videogameFeed.videogame.released
+            released.text = root.context.getString(
+                R.string.released_date,
+                videogameFeed.videogame.released
+            )
             rating.text = videogameFeed.videogame.rating.toString()
+            val genreNames = videogameFeed.videogame.genres
+                .joinToString(", ") { it.name }
+
+            genres.text = itemView.context.getString(R.string.genres, genreNames)
+
 
             btnsave.setImageResource(
                 if (videogameFeed.isFavorite) R.drawable.ic_favorite_click

--- a/app/src/main/res/layout/fragment_videogame_detail.xml
+++ b/app/src/main/res/layout/fragment_videogame_detail.xml
@@ -72,23 +72,13 @@
                     app:layout_constraintStart_toStartOf="parent"/>
 
                 <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/timegame"
-                    android:text="@string/timegame"
-                    style="@style/TextAppearance.GameTracker.Subtitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    app:layout_constraintTop_toBottomOf="@id/released"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/playtime"
                     style="@style/TextAppearance.GameTracker.Subtitle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_small"
                     app:layout_constraintTop_toBottomOf="@id/released"
-                    app:layout_constraintStart_toEndOf="@id/timegame"/>
+                    app:layout_constraintStart_toStartOf="parent"/>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_videogames_item.xml
+++ b/app/src/main/res/layout/view_videogames_item.xml
@@ -78,6 +78,15 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintBottom_toBottomOf="parent"/>
 
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/genres"
+                    style="@style/TextAppearance.GameTracker.Subtitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/image"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="played">Played</string>
     <string name="setting">Setting</string>
     <string name="save">Guardar</string>
-    <string name="timegame">Horas de Juego:</string>
+    <string name="playtime">Horas de Juego: %sH</string>
+    <string name="genres">Genres: %s</string>
+    <string name="released_date">Released date: %s</string>
 
 </resources>


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
Se pedía ocultar la API Key para tener más seguridad y, además, añadir al listado de videojuegos que muestre los géneros para poder utilizarlos en la UI.

## 💡 Proceso seguido para resolver el problema
- Configurar `local.properties` y cargar la clave desde Gradle (`buildConfigField`) para que no quede hardcodeada.  
- Habilitar `buildFeatures.buildConfig = true` en `app/build.gradle.kts` y sincronizar proyecto.  
- Sustituir literales en Retrofit por `BuildConfig.API_KEY`.  
- Extender el modelo de respuesta de la API (`VideogamesApiModel`) para incluir `List<GenreApiModel>`.  
- Crear data classes de dominio `Videogame` y `Genre`, y mapper `toModel()` que transforma `GenreApiModel` → `Genre`.  
- Implementar `TypeConverter` con Gson para persistir `List<Genre>` en Room.  
- Actualizar entidad `VideogamesEntity` y base de datos para usar el converter.  
- Modificar el ViewHolder para mostrar los géneros con `joinToString(", ")`.  
- Añadir chips de Material en el layout si se requiere diseño más avanzado.

## 📝 Pruebas de validación
- Verificado que `BuildConfig.API_KEY` contenga la clave definida en `local.properties` y no aparezca en el repo.  
- Probada la llamada a la API en depuración, confirmando que la key llega por query.  
- Comprobado el parseo de géneros y su almacenamiento en Room usando converter.  
- Validado en UI que los géneros se muestran como texto “Action, RPG” y no como lista de objetos.  
- Probado comportamiento con lista vacía de géneros y con más de 3 ítems (se muestra “+X”).  
- Tests unitarios para el mapper `toModel()` y para los converters de Room.

## 👩‍💻 Resumen de los cambios introducidos
- **Gradle**: carga de `API_KEY` desde `local.properties` y habilitación de `buildConfig`.  
- **Retrofit**: uso de `BuildConfig.API_KEY` en `VideogamesService`.  
- **Modelos**:
  - `VideogamesApiModel` con `genres: List<GenreApiModel>`.
  - Clases de dominio `Videogame` y `Genre`.
  - Mapper `toModel()` que convierte `GenreApiModel` → `Genre`.
- **Room**: 
  - Entidad `VideogamesEntity` con `genres: List<Genre>`.
  - `Converters.kt` con `TypeConverter` JSON ↔ `List<Genre>`.
- **UI**:
  - Layout actualizado para mostrar texto de géneros.
  - `ViewHolder.bind` usa `joinToString` para renderizar nombres.
- **Tests**: nuevos unit tests para mapper y converters.

## 📸 Screenshot o Video
<img width="376" alt="Captura de pantalla 2025-04-17 a las 12 27 54" src="https://github.com/user-attachments/assets/2487828f-994b-4bad-9dbd-b5f90f7abedb" />

<img width="123" alt="Captura de pantalla 2025-04-17 a las 12 28 02" src="https://github.com/user-attachments/assets/40c21df4-e50e-4efe-86fc-93f393330bfe" />

## ✋ Notas adicionales (Disclaimer)
Nada relevantep.

## 🌈 Añade un Gif que represente a esta PR
![Celebración](https://media.giphy.com/media/3o7TKMt1VVNkHV2PaE/giphy.gif)

## ✅ Checklist
- [x] La rama tiene el formato correcto: `feature/21-ocultar-api-key-y-generos`.  
- [x] He añadido un título descriptivo
