### PR TITLE
Añadido la opcion de Recarga y Compartir

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,17 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:targetApi="31">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
@@ -27,5 +38,4 @@
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />
     </application>
-
 </manifest>

--- a/app/src/main/java/edu/iesam/gametracker/app/presentation/ContentShare.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/presentation/ContentShare.kt
@@ -2,6 +2,7 @@ package edu.iesam.gametracker.app.presentation
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import org.koin.core.annotation.Single
 
 @Single
@@ -18,5 +19,21 @@ class ContentShare(private val context: Context) {
         val shareIntent = Intent.createChooser(sendIntent, null)
         shareIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         context.startActivity(shareIntent)
+    }
+
+    fun shareContentWithImage(title: String, textToShare: String, imageUri: Uri) {
+        Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TITLE, title)
+            putExtra(Intent.EXTRA_TEXT, textToShare)
+            putExtra(Intent.EXTRA_STREAM, imageUri)
+            type = "image/*"
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }.let { intent ->
+            context.startActivity(
+                Intent.createChooser(intent, title)
+                    .apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+            )
+        }
     }
 }

--- a/app/src/main/java/edu/iesam/gametracker/app/presentation/ContentShare.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/presentation/ContentShare.kt
@@ -1,0 +1,22 @@
+package edu.iesam.gametracker.app.presentation
+
+import android.content.Context
+import android.content.Intent
+import org.koin.core.annotation.Single
+
+@Single
+class ContentShare(private val context: Context) {
+
+    fun shareContent(title: String, textToShare: String) {
+        val sendIntent: Intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TITLE, title)
+            putExtra(Intent.EXTRA_TEXT, textToShare)
+            type = "text/plain"
+        }
+
+        val shareIntent = Intent.createChooser(sendIntent, null)
+        shareIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(shareIntent)
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesAdapter.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesAdapter.kt
@@ -1,5 +1,6 @@
 package edu.iesam.gametracker.features.videogames.presentation
 
+import android.graphics.Bitmap
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
@@ -12,7 +13,7 @@ class VideogamesAdapter() :
 
     private var onItemClick: ((Videogame) -> Unit)? = null
     private var onDetailClick: ((Videogame) -> Unit)? = null
-    private var onShareClick: ((Videogame) -> Unit)? = null
+    private var onShareClick: ((Videogame, bitmap: Bitmap?) -> Unit)? = null
 
     fun setOnItemClickListener(listener: (Videogame) -> Unit) {
         onItemClick = listener
@@ -22,9 +23,10 @@ class VideogamesAdapter() :
         onDetailClick = listener
     }
 
-    fun setOnShareClickListener(listener: (Videogame) -> Unit) {
+    fun setOnShareClickListener(listener: (Videogame, Bitmap?) -> Unit) {
         onShareClick = listener
     }
+
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideogamesViewHolder {
         val view = LayoutInflater.from(parent.context)

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesAdapter.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesAdapter.kt
@@ -12,6 +12,7 @@ class VideogamesAdapter() :
 
     private var onItemClick: ((Videogame) -> Unit)? = null
     private var onDetailClick: ((Videogame) -> Unit)? = null
+    private var onShareClick: ((Videogame) -> Unit)? = null
 
     fun setOnItemClickListener(listener: (Videogame) -> Unit) {
         onItemClick = listener
@@ -21,6 +22,10 @@ class VideogamesAdapter() :
         onDetailClick = listener
     }
 
+    fun setOnShareClickListener(listener: (Videogame) -> Unit) {
+        onShareClick = listener
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideogamesViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(R.layout.view_videogames_item, parent, false)
@@ -28,6 +33,6 @@ class VideogamesAdapter() :
     }
 
     override fun onBindViewHolder(holder: VideogamesViewHolder, position: Int) {
-        holder.bind(currentList[position], onItemClick, onDetailClick)
+        holder.bind(currentList[position], onItemClick, onDetailClick, onShareClick)
     }
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
@@ -16,6 +16,7 @@ class VideogamesViewHolder(private val view: View) : RecyclerView.ViewHolder(vie
         videogameFeed: GetVideogamesUseCase.VideoGameFeed,
         onClick: ((Videogame) -> Unit)?,
         onDetailClick: ((Videogame) -> Unit)?,
+        onShareClick: ((Videogame) -> Unit)?
     ) {
 
 
@@ -49,6 +50,11 @@ class VideogamesViewHolder(private val view: View) : RecyclerView.ViewHolder(vie
                     onDetailClick.invoke(videogameFeed.videogame)
                 }
             }
+
+            btnShare.setOnClickListener {
+                onShareClick?.invoke(videogameFeed.videogame)
+            }
+
         }
     }
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
@@ -1,5 +1,7 @@
 package edu.iesam.gametracker.features.videogames.presentation
 
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import edu.iesam.gametracker.R
@@ -10,51 +12,39 @@ import edu.iesam.gametracker.features.videogames.domain.Videogame
 
 class VideogamesViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
 
-    private val binding: ViewVideogamesItemBinding = ViewVideogamesItemBinding.bind(view)
+    private val binding = ViewVideogamesItemBinding.bind(view)
 
     fun bind(
         videogameFeed: GetVideogamesUseCase.VideoGameFeed,
         onClick: ((Videogame) -> Unit)?,
         onDetailClick: ((Videogame) -> Unit)?,
-        onShareClick: ((Videogame) -> Unit)?
+        onShareClick: ((Videogame, Bitmap?) -> Unit)?
     ) {
-
+        val videogame = videogameFeed.videogame
 
         binding.apply {
-            image.loadUrl(videogameFeed.videogame.backgroundImage)
-            nameGame.text = videogameFeed.videogame.name
+            image.loadUrl(videogame.backgroundImage)
+            nameGame.text = videogame.name
             released.text = root.context.getString(
                 R.string.released_date,
-                videogameFeed.videogame.released
+                videogame.released
             )
-            rating.text = videogameFeed.videogame.rating.toString()
-            val genreNames = videogameFeed.videogame.genres
-                .joinToString(", ") { it.name }
-
-            genres.text = itemView.context.getString(R.string.genres, genreNames)
-
+            rating.text = videogame.rating.toString()
+            val genreNames = videogame.genres.joinToString(", ") { it.name }
+            genres.text = root.context.getString(R.string.genres, genreNames)
 
             btnsave.setImageResource(
                 if (videogameFeed.isFavorite) R.drawable.ic_favorite_click
                 else R.drawable.ic_save
             )
-
-            onClick?.let {
-                btnsave.setOnClickListener {
-                    onClick.invoke(videogameFeed.videogame)
-                }
-            }
-
-            onDetailClick?.let {
-                root.setOnClickListener {
-                    onDetailClick.invoke(videogameFeed.videogame)
-                }
-            }
+            btnsave.setOnClickListener { onClick?.invoke(videogame) }
+            root.setOnClickListener { onDetailClick?.invoke(videogame) }
 
             btnShare.setOnClickListener {
-                onShareClick?.invoke(videogameFeed.videogame)
+                val bitmap = (image.drawable as? BitmapDrawable)?.bitmap
+                onShareClick?.invoke(videogame, bitmap)
             }
-
         }
     }
 }
+

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,5 +1,5 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
       
-    <path android:fillColor="@android:color/white" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M16,5l-1.42,1.42 -1.59,-1.59L12.99,16h-1.98L11.01,4.83L9.42,6.42 8,5l4,-4 4,4zM20,10v11c0,1.1 -0.9,2 -2,2L6,23c-1.11,0 -2,-0.9 -2,-2L4,10c0,-1.11 0.89,-2 2,-2h3v2L6,10v11h12L18,10h-3L15,8h3c1.1,0 2,0.89 2,2z"/>
     
 </vector>

--- a/app/src/main/res/layout/fragment_videogames.xml
+++ b/app/src/main/res/layout/fragment_videogames.xml
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/videogame_list"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swiperefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:padding="0dp"
-        android:clipToPadding="false"
-        tools:listitem="@layout/view_videogames_item"/>
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/videogame_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:padding="0dp"
+            tools:listitem="@layout/view_videogames_item" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_videogames_item.xml
+++ b/app/src/main/res/layout/view_videogames_item.xml
@@ -87,6 +87,16 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     />
 
+                <ImageView
+                    android:id="@+id/btnShare"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_share"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/btnsave"
+                    android:paddingEnd="@dimen/button_padding_vertical"
+                    />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,5 +8,7 @@
     <string name="playtime">Horas de Juego: %sH</string>
     <string name="genres">Genres: %s</string>
     <string name="released_date">Released date: %s</string>
+    <string name="share_chooser_title">Compartir videojuego</string>
+    <string name="share_body">🎮 %s 📅 Lanzamiento: %s</string>
 
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="shared_images" path="." />
+</paths>


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
En la pantalla de lista de videojuegos actualmente no existe un mecanismo para:
- **Recargar**
- **Compartir** la información de un videojuego (título, imagen y fecha), limitando la difusión de contenido desde la app.

## 💡 Proceso seguido para resolver el problema
- Investigamos el componente `SwipeRefreshLayout` de Android para implementar pull-to-refresh.  
- Consultamos la documentación oficial de [SwipeRefreshLayout](https://developer.android.com/jetpack/androidx/releases/swiperefreshlayout) y ejemplos de uso.  
- Diseñamos un icono de compartir (`ic_share`) en el layout del ítem de juego con Material Components.  
- Implementamos un helper `ContentShare` para encapsular el Intent de compartir nativo de Android.  

## 📝 Pruebas de validación
- Verificamos que al tirar hacia abajo sobre la lista (pull-to-refresh) se dispara `viewModel.loadGames()`
- Validamos que al pulsar el icono de compartir abre el diálogo nativo con el título, imagen y fecha del juego.  
- Realizamos pruebas en dispositivos con distintos tamaños de pantalla y versiones de Android.

## 👩‍💻 Resumen de los cambios introducidos
- **UI**  
  - Envuelto el `RecyclerView` en un `SwipeRefreshLayout` con spinner de recarga.  
  - Añadido icono `ic_share` en cada tarjeta de videojuego para compartir.  
- **ViewModel**  
  - Expuesto `isLoading` para controlar el estado de refresco.  
- **Helper**  
  - Creado `ContentShare` para unificar la lógica de compartir con `Intent.ACTION_SEND`.  

## 📸 Screenshot o Video
<img width="365" alt="Captura de pantalla 2025-04-18 a las 13 42 55" src="https://github.com/user-attachments/assets/c957a81a-c7bf-49a0-828e-19936de584d4" />

## ✋ Notas adicionales (Disclaimer)
- No se han introducido cambios en la base de datos ni en la lógica de persistencia de videojuegos.  
- El comportamiento de compartir sólo funciona si la tarjeta ha cargado correctamente la imagen en cache.

## 🌈 Añade un Gif que represente a esta PR
![chefs-kiss-french-chef](https://github.com/user-attachments/assets/4605dc84-7ed2-4b7a-bfef-cd3154e34cb0)

## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He relacionado la PR con la Issue.
