### PR TITLE
Añadido la parte de recursos a ajustes

### DIFF
--- a/app/src/main/java/edu/iesam/gametracker/app/GameTrackerApp.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/GameTrackerApp.kt
@@ -6,6 +6,7 @@ import edu.iesam.gametracker.app.di.AppModule
 import edu.iesam.gametracker.app.di.LocalModule
 import edu.iesam.gametracker.app.di.RemoteModule
 import edu.iesam.gametracker.features.setting.di.DeveloperModule
+import edu.iesam.gametracker.features.setting.di.ResourcesModule
 import edu.iesam.gametracker.features.videogames.di.VideogamesModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -24,7 +25,8 @@ class GameTrackerApp : Application() {
                 RemoteModule().module,
                 LocalModule().module,
                 VideogamesModule().module,
-                DeveloperModule().module
+                DeveloperModule().module,
+                ResourcesModule().module
             )
         }
     }

--- a/app/src/main/java/edu/iesam/gametracker/app/data/local/db/GameTrackerDataBase.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/data/local/db/GameTrackerDataBase.kt
@@ -6,6 +6,8 @@ import androidx.room.TypeConverters
 import edu.iesam.gametracker.app.data.local.db.converters.Converters
 import edu.iesam.gametracker.features.setting.data.developer.local.DeveloperEntity
 import edu.iesam.gametracker.features.setting.data.developer.local.DeveloperDao
+import edu.iesam.gametracker.features.setting.data.resources.local.ResourcesDao
+import edu.iesam.gametracker.features.setting.data.resources.local.ResourcesEntity
 import edu.iesam.gametracker.features.videogames.data.local.db.FavoriteDao
 import edu.iesam.gametracker.features.videogames.data.local.db.FavoriteEntity
 import edu.iesam.gametracker.features.videogames.data.local.db.VideogamesDao
@@ -15,9 +17,10 @@ import edu.iesam.gametracker.features.videogames.data.local.db.VideogamesEntity
     entities = [
         VideogamesEntity::class,
         FavoriteEntity::class,
-        DeveloperEntity::class
+        DeveloperEntity::class,
+        ResourcesEntity::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 
@@ -25,5 +28,6 @@ import edu.iesam.gametracker.features.videogames.data.local.db.VideogamesEntity
 abstract class GameTrackerDataBase : RoomDatabase() {
     abstract fun videogamesDao(): VideogamesDao
     abstract fun favoriteDao(): FavoriteDao
-    abstract fun settingDao(): DeveloperDao
+    abstract fun developerDao(): DeveloperDao
+    abstract fun resourcesDao(): ResourcesDao
 }

--- a/app/src/main/java/edu/iesam/gametracker/app/extensions/ImageViewExt.kt
+++ b/app/src/main/java/edu/iesam/gametracker/app/extensions/ImageViewExt.kt
@@ -2,7 +2,10 @@ package edu.iesam.gametracker.app.extensions
 
 import android.widget.ImageView
 import coil.load
+import edu.iesam.gametracker.R
 
 fun ImageView.loadUrl(url: String) {
-    this.load(url)
+    this.load(url) {
+        placeholder(R.drawable.ic_load)
+    }
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/developer/local/DeveloperDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/developer/local/DeveloperDbLocalDataSource.kt
@@ -4,11 +4,11 @@ import edu.iesam.gametracker.features.setting.domain.developer.Developer
 import org.koin.core.annotation.Single
 
 @Single
-class DeveloperDbLocalDataSource(private val settingDao: DeveloperDao) {
+class DeveloperDbLocalDataSource(private val developerDao: DeveloperDao) {
 
 
     suspend fun findAllDevelopers(): Result<List<Developer>> {
-        val developers = settingDao.findAllDevelopers()
+        val developers = developerDao.findAllDevelopers()
         return if (developers.isEmpty()) {
             Result.success(emptyList())
         } else {
@@ -20,5 +20,6 @@ class DeveloperDbLocalDataSource(private val settingDao: DeveloperDao) {
         val developerList = developers.map {
             it.toEntity()
         }
+        developerDao.saveDevelopers(*developerList.toTypedArray())
     }
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/ResourcesDataRepository.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/ResourcesDataRepository.kt
@@ -1,0 +1,29 @@
+package edu.iesam.gametracker.features.setting.data.resources
+
+import edu.iesam.gametracker.features.setting.data.resources.local.ResourcesDbLocalDataSource
+import edu.iesam.gametracker.features.setting.data.resources.remote.ResourcesFirebaseDataSource
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+import edu.iesam.gametracker.features.setting.domain.resources.ResourcesRepository
+import org.koin.core.annotation.Single
+
+@Single
+class ResourcesDataRepository(
+    private val remote: ResourcesFirebaseDataSource,
+    private val local: ResourcesDbLocalDataSource
+) : ResourcesRepository {
+
+    override suspend fun getResources(): Result<List<Resources>> {
+        val resourcesLocal = local.findAllResources()
+        if (resourcesLocal.isSuccess) {
+            val localResources = resourcesLocal.getOrNull()
+            if (!localResources.isNullOrEmpty()) {
+                return Result.success(localResources)
+            }
+        }
+        val resourcesFromRemote = remote.getResources()
+        return resourcesFromRemote.onSuccess {
+            local.saveResources(it)
+        }
+    }
+
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/DbMappers.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/DbMappers.kt
@@ -1,0 +1,21 @@
+package edu.iesam.gametracker.features.setting.data.resources.local
+
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+
+fun Resources.toEntity(): ResourcesEntity {
+    return ResourcesEntity(
+        this.id,
+        this.image,
+        this.name,
+        this.urlWeb
+    )
+}
+
+fun ResourcesEntity.toDomain(): Resources {
+    return Resources(
+        this.id,
+        this.image,
+        this.name,
+        this.urlWeb
+    )
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/ResourcesDao.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/ResourcesDao.kt
@@ -1,0 +1,16 @@
+package edu.iesam.gametracker.features.setting.data.resources.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ResourcesDao {
+
+    @Query("SELECT * FROM $RESOURCE_TABLE")
+    suspend fun getAll(): List<ResourcesEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveResources(vararg resources: ResourcesEntity)
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/ResourcesDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/ResourcesDbLocalDataSource.kt
@@ -1,0 +1,24 @@
+package edu.iesam.gametracker.features.setting.data.resources.local
+
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+import org.koin.core.annotation.Single
+
+@Single
+class ResourcesDbLocalDataSource(private val resourcesDao: ResourcesDao) {
+
+    suspend fun findAllResources(): Result<List<Resources>> {
+        val resources = resourcesDao.getAll()
+        return if (resources.isEmpty()) {
+            Result.success(emptyList())
+        } else {
+            Result.success(resources.map { it.toDomain() })
+        }
+    }
+
+    suspend fun saveResources(resources: List<Resources>) {
+        val resourcesList = resources.map {
+            it.toEntity()
+        }
+        resourcesDao.saveResources(*resourcesList.toTypedArray())
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/ResourcesEntity.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/local/ResourcesEntity.kt
@@ -1,0 +1,16 @@
+package edu.iesam.gametracker.features.setting.data.resources.local
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+const val RESOURCE_TABLE = "resources"
+const val RESOURCE_ID = "id"
+
+@Entity(tableName = RESOURCE_TABLE)
+class ResourcesEntity (
+    @PrimaryKey @ColumnInfo(name = RESOURCE_ID) val id: Int,
+    @ColumnInfo(name = "image") val image: String,
+    @ColumnInfo(name = "name") val name: String,
+    @ColumnInfo(name = "url_web") val urlWeb: String
+)

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/remote/ResourcesFirebaseDataSource.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/remote/ResourcesFirebaseDataSource.kt
@@ -1,0 +1,21 @@
+package edu.iesam.gametracker.features.setting.data.resources.remote
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+import kotlinx.coroutines.tasks.await
+import org.koin.core.annotation.Single
+
+@Single
+class ResourcesFirebaseDataSource(private val firestore: FirebaseFirestore) {
+
+    suspend fun getResources(): Result<List<Resources>> {
+        val resources = firestore.collection("resources")
+            .get()
+            .await()
+            .map {
+                it.toObject(ResourcesFirebaseModel::class.java).toModel()
+            }
+        return Result.success(resources)
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/remote/ResourcesFirebaseMapper.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/remote/ResourcesFirebaseMapper.kt
@@ -1,0 +1,12 @@
+package edu.iesam.gametracker.features.setting.data.resources.remote
+
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+
+fun ResourcesFirebaseModel.toModel(): Resources{
+    return Resources(
+        this.id,
+        this.image,
+        this.name,
+        this.urlWeb
+    )
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/remote/ResourcesFirebaseModel.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/data/resources/remote/ResourcesFirebaseModel.kt
@@ -1,0 +1,11 @@
+package edu.iesam.gametracker.features.setting.data.resources.remote
+
+import com.google.firebase.firestore.PropertyName
+
+class ResourcesFirebaseModel (
+    var id: Int = 0,
+    var image : String = "",
+    var name: String = "",
+    @get:PropertyName("url_web")
+    @set:PropertyName("url_web") var urlWeb: String = "",
+)

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/di/DeveloperModule.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/di/DeveloperModule.kt
@@ -19,7 +19,7 @@ class DeveloperModule {
 
 
     @Single
-    fun provideResourceDao(db: GameTrackerDataBase): DeveloperDao {
-        return db.settingDao()
+    fun provideDeveloperDao(db: GameTrackerDataBase): DeveloperDao {
+        return db.developerDao()
     }
 }

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/di/ResourcesModule.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/di/ResourcesModule.kt
@@ -1,0 +1,24 @@
+package edu.iesam.gametracker.features.setting.di
+
+import com.google.firebase.firestore.FirebaseFirestore
+import edu.iesam.gametracker.app.data.local.db.GameTrackerDataBase
+import edu.iesam.gametracker.features.setting.data.resources.local.ResourcesDao
+import edu.iesam.gametracker.features.setting.data.resources.remote.ResourcesFirebaseDataSource
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+
+@Module
+@ComponentScan
+class ResourcesModule {
+
+    @Single
+    fun provideResourcesFirebaseRemoteDataSource(db: FirebaseFirestore): ResourcesFirebaseDataSource {
+        return ResourcesFirebaseDataSource(db)
+    }
+
+    @Single
+    fun provideResourcesDao(db: GameTrackerDataBase): ResourcesDao {
+        return db.resourcesDao()
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/domain/resources/GetResourcesUseCase.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/domain/resources/GetResourcesUseCase.kt
@@ -1,0 +1,12 @@
+package edu.iesam.gametracker.features.setting.domain.resources
+
+import org.koin.core.annotation.Single
+
+@Single
+class GetResourcesUseCase(private val resourcesRepository: ResourcesRepository) {
+
+    suspend operator fun invoke(): Result<List<Resources>> {
+        return resourcesRepository.getResources()
+    }
+
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/domain/resources/Resources.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/domain/resources/Resources.kt
@@ -1,0 +1,8 @@
+package edu.iesam.gametracker.features.setting.domain.resources
+
+data class Resources (
+    val id : Int,
+    val image: String,
+    val name: String,
+    val urlWeb: String
+)

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/domain/resources/ResourcesRepository.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/domain/resources/ResourcesRepository.kt
@@ -1,0 +1,5 @@
+package edu.iesam.gametracker.features.setting.domain.resources
+
+interface ResourcesRepository {
+    suspend fun getResources(): Result<List<Resources>>
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/SettingFragment.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/SettingFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import edu.iesam.gametracker.R
 import edu.iesam.gametracker.databinding.FragmentSettingBinding
 import edu.iesam.gametracker.features.setting.presentation.developer.DeveloperBottomSheetDialogFragment
+import edu.iesam.gametracker.features.setting.presentation.resources.ResourcesBottomSheetDialogFragment
 
 class SettingFragment : Fragment(R.layout.fragment_setting) {
 
@@ -35,10 +36,11 @@ class SettingFragment : Fragment(R.layout.fragment_setting) {
             }
 
             TitleResources.setOnClickListener {
-
+                ResourcesBottomSheetDialogFragment()
+                    .show(childFragmentManager, "resources_bottom_sheet")
             }
 
-            // Resto de tu setup (email, versión…)
+
             TitleContact.text = getString(R.string.email)
             ContactMail.text  = getString(R.string.mail)
             ContactMail.setOnClickListener { openEmailClient() }

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesAdapter.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesAdapter.kt
@@ -1,0 +1,22 @@
+package edu.iesam.gametracker.features.setting.presentation.resources
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import edu.iesam.gametracker.R
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+
+class ResourcesAdapter : ListAdapter<Resources, ResourcesViewHolder>(ResourcesDiffUtil()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ResourcesViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.view_item_bottom_sheet_resources, parent, false)
+        return ResourcesViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = currentList.size
+
+    override fun onBindViewHolder(viewHolder: ResourcesViewHolder, position: Int) {
+        viewHolder.bind(currentList[position])
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesBottomSheetDialogFragment.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesBottomSheetDialogFragment.kt
@@ -1,0 +1,69 @@
+package edu.iesam.gametracker.features.setting.presentation.resources
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import edu.iesam.gametracker.databinding.FragmentBottomSheetResourcesBinding
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import kotlin.getValue
+
+class ResourcesBottomSheetDialogFragment : BottomSheetDialogFragment() {
+
+    private var _binding: FragmentBottomSheetResourcesBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ResourcesViewmodel by viewModel()
+    private val resourceAdapter = ResourcesAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentBottomSheetResourcesBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.loadResources()
+        setUpView()
+        setUpObserver()
+    }
+
+    private fun setUpObserver() {
+        val observer = Observer<ResourcesViewmodel.UiState> { uiState ->
+            uiState.resources?.let {
+                resourceAdapter.submitList(it)
+                Log.d("@Dev", "Resources loaded: ${it.size}")
+            }
+            uiState.errorApp?.let {
+
+            }
+        }
+        viewModel.uiState.observe(viewLifecycleOwner, observer)
+    }
+
+    private fun setUpView() {
+        binding.apply {
+            recyclerViewRes.apply {
+                layoutManager = LinearLayoutManager(
+                    context,
+                    LinearLayoutManager.VERTICAL,
+                    false
+                )
+                adapter = resourceAdapter
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesDiffUtil.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesDiffUtil.kt
@@ -1,0 +1,21 @@
+package edu.iesam.gametracker.features.setting.presentation.resources
+
+import androidx.recyclerview.widget.DiffUtil
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+
+class ResourcesDiffUtil : DiffUtil.ItemCallback<Resources>() {
+    override fun areItemsTheSame(
+        oldItem: Resources,
+        newItem: Resources
+    ): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(
+        oldItem: Resources,
+        newItem: Resources
+    ): Boolean {
+        return oldItem == newItem
+    }
+
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesViewHolder.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesViewHolder.kt
@@ -1,0 +1,26 @@
+package edu.iesam.gametracker.features.setting.presentation.resources
+
+import android.util.Log
+import androidx.recyclerview.widget.RecyclerView
+import android.view.View
+import edu.iesam.gametracker.app.extensions.loadUrl
+import edu.iesam.gametracker.app.presentation.AppIntent
+import edu.iesam.gametracker.databinding.ViewItemBottomSheetResourcesBinding
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+
+
+class ResourcesViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
+
+    private val binding = ViewItemBottomSheetResourcesBinding.bind(view)
+
+    fun bind(resource: Resources) {
+        binding.apply {
+            val nav = AppIntent(view.context)
+            iconResource.loadUrl(resource.image)
+            name.text = resource.name
+            item.setOnClickListener {
+                nav.openWebPage(resource.urlWeb)
+            }
+        }
+    }
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesViewmodel.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/setting/presentation/resources/ResourcesViewmodel.kt
@@ -1,0 +1,41 @@
+package edu.iesam.gametracker.features.setting.presentation.resources
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import edu.iesam.gametracker.app.domain.ErrorApp
+import edu.iesam.gametracker.features.setting.domain.developer.Developer
+import edu.iesam.gametracker.features.setting.domain.developer.GetDeveloperUseCase
+import edu.iesam.gametracker.features.setting.domain.resources.GetResourcesUseCase
+import edu.iesam.gametracker.features.setting.domain.resources.Resources
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.android.annotation.KoinViewModel
+
+@KoinViewModel
+class ResourcesViewmodel(
+    private val getResourcesUseCase: GetResourcesUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
+    fun loadResources() {
+        _uiState.value = UiState(isLoading = true)
+        viewModelScope.launch(Dispatchers.IO) {
+            val resources = getResourcesUseCase()
+            if (resources.getOrNull() != null) {
+                _uiState.postValue(UiState(resources = resources.getOrNull()))
+            } else {
+                _uiState.postValue(UiState(errorApp = resources.exceptionOrNull() as ErrorApp?))
+            }
+        }
+    }
+
+    data class UiState(
+        val isLoading: Boolean = false,
+        val errorApp: ErrorApp? = null,
+        val resources: List<Resources>? = null
+    )
+}

--- a/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
+++ b/app/src/main/java/edu/iesam/gametracker/features/videogames/presentation/VideogamesViewHolder.kt
@@ -31,7 +31,7 @@ class VideogamesViewHolder(private val view: View) : RecyclerView.ViewHolder(vie
             )
             rating.text = videogame.rating.toString()
             val genreNames = videogame.genres.joinToString(", ") { it.name }
-            genres.text = root.context.getString(R.string.genres, genreNames)
+            genres.text = view.context.getString(R.string.genres, genreNames)
 
             btnsave.setImageResource(
                 if (videogameFeed.isFavorite) R.drawable.ic_favorite_click

--- a/app/src/main/res/drawable/ic_load.xml
+++ b/app/src/main/res/drawable/ic_load.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM17,13l-5,5 -5,-5h3V9h4v4h3z"/>
+    
+</vector>

--- a/app/src/main/res/layout/fragment_bottom_sheet_resources.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_resources.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view_res"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:listitem="@layout/view_item_bottom_sheet_resources" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_item_bottom_sheet_resources.xml
+++ b/app/src/main/res/layout/view_item_bottom_sheet_resources.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingTop="@dimen/button_padding_vertical">
 
     <androidx.cardview.widget.CardView
         android:id="@+id/item"
@@ -19,8 +20,8 @@
 
             <ImageView
                 android:id="@+id/icon_resource"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
+                android:layout_height="50dp"
+                android:layout_width="50dp"
                 tools:src="@tools:sample/avatars" />
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/view_item_bottom_sheet_resources.xml
+++ b/app/src/main/res/layout/view_item_bottom_sheet_resources.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/item"
+        app:cardCornerRadius="24dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/icon_resource"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                tools:src="@tools:sample/avatars" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1">
+                <TextView
+                    android:id="@+id/name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/author"
+                    android:gravity="center_horizontal"
+                    tools:text="Recursos" />
+
+                <TextView
+                    android:id="@+id/author"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    android:gravity="center_horizontal"
+                    tools:text="Autor" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver
Implementar la pantalla de **Recursos** en la aplicación Android, usando **Firebase Cloud Firestore** para persistir y recuperar los datos. La pantalla debe mostrar un listado sencillo de cada recurso con su título, imagen y enlace (URL) enlazable.  

## 💡 Proceso seguido para resolver el problema
- Repaso de la documentación oficial de Firebase y Cloud Firestore para configurar el proyecto y las dependencias.
- Diseño de los modelos de datos (`ResourcesFirebaseModel` y `Resources`), el mapeador y el repositorio remoto (`ResourcesFirebaseDataSource`).
- Implementación de la capa de dominio (`GetResourcesUseCase`, `ResourcesRepository`) y local caching.
- Creación del ViewModel (`ResourcesViewmodel`) y del BottomSheet (`ResourcesBottomSheetDialogFragment`) con su Adapter y ViewHolder.
- Ajuste de la extensión `ImageView.loadUrl` para Coil, añadiendo `placeholder()`.

## 📝 Pruebas de validación
- Fragmentos de código de prueba en un proyecto de staging para verificar la consulta a Firestore y el mapeo de campos.
- Pruebas manuales del BottomSheet abriendo la sección Recursos desde Settings.
- Verificación de que las URLs de imagen se loguean correctamente en Logcat y que Coil muestra el placeholder y luego la imagen remota.
- Comprobación de que al hacer clic en un recurso, se abre la URL en el navegador.

## 👩‍💻 Resumen de los cambios introducidos
- **Firebase / Firestore**  
  - Configuración del proyecto con la dependencia de Firestore.  
  - Modelo `ResourcesFirebaseModel`, mapper `toModel()`, y datasource `ResourcesFirebaseDataSource`.  
  - Repositorio `ResourcesDataRepository` que combina remoto y local.  
- **Dominio**  
  - Interface `ResourcesRepository` y caso de uso `GetResourcesUseCase`.  
- **Presentación**  
  - `ResourcesViewmodel` con LiveData de estado.  
  - `ResourcesBottomSheetDialogFragment` implementado con RecyclerView.  
  - Adapter (`ResourcesAdapter`), DiffUtil, ViewHolder y layout `view_item_bottom_sheet_resources.xml`.  
- **UI Extensions**  
  - Refactor de `ImageView.loadUrl` para Coil con builder y `error()/placeholder()`.  

## 📸 Screenshot o Video
<img width="396" alt="Captura de pantalla 2025-04-29 a las 22 01 52" src="https://github.com/user-attachments/assets/4bb0e18f-32a4-4fed-aadf-37db18a65ede" />

## ✋ Notas adicionales (Disclaimer)
- Asegúrate de tener reglas mínimas de lectura en Firestore (podrían ajustarse en producción).
- Si no ves imágenes, comprueba tu token de red y permisos de Internet.

## 🌈 Añade un Gif que represente a esta PR
![GIF de celebración o de loading completo](https://media.giphy.com/media/3o6ZsWgdJf0WdTNQla/giphy.gif)  

## ✅ Checklist
- [x] La rama tiene el formato correcto: `feature/42/implement-resources-screen`.  
- [x] He añadido un título a la PR descriptivo.  
- [x] Me he asignado como autor.  
- [x] He relacionado la PR con la Issue #42.  
